### PR TITLE
0.4.24.1

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -121,7 +121,6 @@ jobs:
   
     name: Auto-Release pushed tag
     needs: sign
-    if: github.event.pull_request.merged
     runs-on: ubuntu-22.04
     steps:
       - uses: actions/checkout@v3
@@ -136,10 +135,18 @@ jobs:
           GITHUB_TOKEN: ${{ secrets.PAT_1 }}
           tag: ${{ steps.merged-pr-info.outputs.title }}
         run: |
+          # create a new release notes file
+          touch D:\a\Package\release_notes.md
+          # mark that the release was auto-generated
+          echo "## What's Changed in `${tag}`" > D:\a\Package\release_notes.md
+          echo "**This release was generated automatically. It may not be complete or accurate.**" >> D:\a\Package\release_notes.md
+          # create the release
           gh release create "$tag" \
               --repo="$GITHUB_REPOSITORY" \
               --title="${tag#v}" \
-              --generate-notes
+              # --generate-notes
+          # edit the release notes to use the release notes file
+          gh release edit ${tag#v} --notes-file D:\a\Package\release_notes.md
       
       - name: Upload MSIX to release
         env:


### PR DESCRIPTION
Improve the notes included in the automatically generated releases; include a warning that the release was generated automatically and may be incomplete or flawed.

Remove the conditional check for PR merged. Caused Actions to skip the auto-release step.