### PR TITLE
0.5.04

### DIFF
--- a/.github/workflows/cicd.yml
+++ b/.github/workflows/cicd.yml
@@ -120,7 +120,7 @@ jobs:
       - name: Download MSIX package
         uses: actions/download-artifact@v4
         with:
-          name: latest-windows-package
+          name: latest-windows-signed
           path: |
             D:\a\Package
 


### PR DESCRIPTION
An artifact name error was causing the workflow to upload the unsigned application to the release. The name has been changed to reference the signed artifact.