### PR TITLE
bug/128

### DIFF
--- a/LotCoMPrinter/Models/Datasources/Part.cs
+++ b/LotCoMPrinter/Models/Datasources/Part.cs
@@ -33,4 +33,9 @@ public partial class Part(string ParentProcess, string PartNumber, string PartNa
     /// </summary>
     [ObservableProperty]
     public partial string ModelNumber {get; set;} = ModelNumber;
+
+    /// <summary>
+    /// A string formatted to conveniently display the Part's Number and Name together.
+    /// </summary>
+    public string GetPartInfo => $"{PartNumber}\n  {PartName}";
 }

--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -245,7 +245,7 @@
                 <Picker
                     x:Name="PartPicker"
                     ItemsSource="{Binding SelectedProcessParts}"
-                    ItemDisplayBinding="{Binding PartNumber}"
+                    ItemDisplayBinding="{Binding GetPartInfo}"
                     SelectedIndex="-1"
                     SelectedIndexChanged="OnPartSelection"/>
             </Border>


### PR DESCRIPTION
Resolve #128.

Implements `GetPartInfo` computed property on `Part.cs`. Formats `Part.PartNumber` and `Part.PartName` into a singular string that the `PartPicker.ItemDisplayBinding` property can bind to.

This addresses the issue of clarity when displaying Parts in the UI. By supplying both Part Number and Name, the user can clearly see the difference between each Part. Additionally, they can tell what the Part should be immediately.

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>