### PR TITLE
feature/146

### DIFF
--- a/LotCoMPrinter/Models/Datasources/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicket.cs
@@ -255,14 +255,14 @@ public partial class PrintTicket(Department Department, Process Process, Part Pa
         // check for and parse partial data sets
         PartialDataSet? FirstPartialDataSet = null;
         PartialDataSet? SecondPartialDataSet = null;
-        if (Line.Contains("FirstPartialDataSet"))
+        if (JSON.ContainsKey("FirstPartialDataSet"))
         {
             int Quantity = int.Parse(JSON["FirstPartialDataSet"]!["Quantity"]!.ToString());
             int Shift = int.Parse(JSON["FirstPartialDataSet"]!["Shift"]!.ToString());
             string Operator = JSON["FirstPartialDataSet"]!["Operator"]!.ToString();
             FirstPartialDataSet = new PartialDataSet(Quantity, Shift, Operator);
         }
-        if (Line.Contains("SecondPartialDataSet"))
+        if (JSON.ContainsKey("SecondPartialDataSet"))
         {
             int Quantity = int.Parse(JSON["SecondPartialDataSet"]!["Quantity"]!.ToString());
             int Shift = int.Parse(JSON["SecondPartialDataSet"]!["Shift"]!.ToString());

--- a/LotCoMPrinter/Models/Datasources/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicket.cs
@@ -1,7 +1,6 @@
-using System.Diagnostics;
-using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using LotCoMPrinter.Models.Options;
+using Newtonsoft.Json;
 using Newtonsoft.Json.Linq;
 
 namespace LotCoMPrinter.Models.Datasources;

--- a/LotCoMPrinter/Models/Datasources/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicket.cs
@@ -1,5 +1,8 @@
+using System.Diagnostics;
+using System.Text.Json;
 using CommunityToolkit.Mvvm.ComponentModel;
 using LotCoMPrinter.Models.Options;
+using Newtonsoft.Json.Linq;
 
 namespace LotCoMPrinter.Models.Datasources;
 
@@ -12,7 +15,7 @@ namespace LotCoMPrinter.Models.Datasources;
 /// <param name="SerializationMode">The type of Serial Number used to Serialize this Print Ticket.</param>
 /// <param name="SerialNumber"></param>
 /// <param name="ProductionDate"></param>
-public partial class PrintTicket(Department Department, Process Process, Part Part, SerializationModes SerializationMode, SerialNumber SerialNumber, Timestamp ProductionDate) : ObservableObject()
+public partial class PrintTicket(Department Department, Process Process, Part Part, SerializationModes SerializationMode, SerialNumber SerialNumber, Timestamp ProductionDate, PartialDataSet? FirstPartialDataSet = null, PartialDataSet? SecondPartialDataSet = null) : ObservableObject()
 {
     /// <summary>
     /// The Department that initiated this Print Ticket.
@@ -44,7 +47,7 @@ public partial class PrintTicket(Department Department, Process Process, Part Pa
     /// </summary>
     private readonly Timestamp ProductionDate = ProductionDate;
 
-    private PartialDataSet? _firstPartialDataSet = null;
+    private PartialDataSet? _firstPartialDataSet = FirstPartialDataSet;
     /// <summary>
     /// The first of the Partial Production Data sets associated with this Print Ticket.
     /// </summary>
@@ -59,7 +62,7 @@ public partial class PrintTicket(Department Department, Process Process, Part Pa
         }
     }
 
-    private PartialDataSet? _secondPartialDataSet = null;
+    private PartialDataSet? _secondPartialDataSet = SecondPartialDataSet;
     /// <summary>
     /// The second of the Partial Production Data sets associated with this Print Ticket.
     /// </summary>
@@ -145,6 +148,130 @@ public partial class PrintTicket(Department Department, Process Process, Part Pa
         HasFirstPartialDataSet = true;
         HasSecondPartialDataSet = false;
         HasSpace = true;
+    }
+
+    /// <summary>
+    /// Converts the PrintTicket object to a JSON stream.
+    /// </summary>
+    /// <returns></returns>
+    public string ToJSON()
+    {
+        // convert non-string SerializationModes type to a string
+        string ModeString;
+        if (SerializationMode == SerializationModes.JBK)
+        {
+            ModeString = "JBK";
+        } 
+        else
+        {
+            ModeString = "Lot";
+        }
+        // build the JSON stream piece-by-piece
+        // Department, Process, Part, SerializationMode, SerialNumber, and Production Date are all universal
+        string JSON = 
+            "{" +
+                "Department:{" +
+                    $"Title:{Department.Title}" +
+                "}," + 
+                "Process:{" +
+                    $"FullName:{Process.FullName}" +
+                "}," +
+                "Part:{" +
+                    $"PartNumber:{Part.PartNumber}" + 
+                "}," +
+                $"SerializationMode:{ModeString}," +
+                $"SerialNumber:{SerialNumber.ToJSON()}," +
+                $"ProductionDate:{ProductionDate.Stamp}";
+        // add partial data sets only if assigned
+        if (HasFirstPartialDataSet)
+        {
+            JSON += 
+                ",FirstPartialDataSet:{" +
+                    $"Quantity:{FirstPartialDataSet!.Quantity}," +
+                    $"Shift:{FirstPartialDataSet!.Shift}," +
+                    $"Operator:{FirstPartialDataSet!.Operator}" +
+                "}";
+        }
+        if (HasSecondPartialDataSet)
+        {
+            JSON += 
+                ",SecondPartialDataSet:{" +
+                    $"Quantity:{SecondPartialDataSet!.Quantity}," +
+                    $"Shift:{SecondPartialDataSet!.Shift}," +
+                    $"Operator:{SecondPartialDataSet!.Operator}" +
+                "}";
+        }
+        // close the JSON stream
+        JSON += 
+            "}";
+        return JSON;
+    }
+
+    /// <summary>
+    /// Attempts to parse a full PrintTicket object from a JSON formatted Line.
+    /// </summary>
+    /// <param name="Line"></param>
+    /// <returns>A PrintTicket object.</returns>
+    /// <exception cref="JsonException"></exception>
+    public static async Task<PrintTicket> ParseJSON(string Line)
+    {
+        // parse Line into JTokens
+        JObject JSON = JObject.Parse(Line);
+        // attempt to find Department, Process, and Part in the Process Masterlist
+        ProcessData Data = new ProcessData();
+        Department Department;
+        Process Process;
+        Part Part;
+        try
+        {
+            Department = await Data.GetIndividualDepartmentAsync(JSON["Department"]!["Title"]!.ToString());
+            Process = await Data.GetIndividualProcessAsync(JSON["Process"]!["FullName"]!.ToString());
+            Part = await Data.GetProcessPartDataAsync(Process.FullName, JSON["Part"]!["PartNumber"]!.ToString());
+        }
+        catch
+        {
+            throw new JsonException($"Could not parse a Department, Process, and/or Part from '{Line}'.");
+        }
+        // convert the SerializationMode from string to actual enum value and parse the SerialNumber
+        SerializationModes Mode;
+        if (JSON["SerializationMode"]!.Equals("JBK"))
+        {
+            Mode = SerializationModes.JBK;
+        }
+        else
+        {
+            Mode = SerializationModes.Lot;
+        }
+        SerialNumber Number = await SerialNumber.ParseJSON(JSON["SerialNumber"]!.ToString());
+        // parse out a timestamp for ProductionDate
+        Timestamp Date;
+        if (DateTime.TryParse(JSON["ProductionDate"]!.ToString(), out DateTime ParsedStamp))
+        {
+            Date = new Timestamp(ParsedStamp);
+        }
+        else
+        {
+            throw new JsonException($"Could not parse a Production Date from '{Line}'.");
+        }
+        // check for and parse partial data sets
+        PartialDataSet? FirstPartialDataSet = null;
+        PartialDataSet? SecondPartialDataSet = null;
+        if (Line.Contains("FirstPartialDataSet"))
+        {
+            int Quantity = int.Parse(JSON["FirstPartialDataSet"]!["Quantity"]!.ToString());
+            int Shift = int.Parse(JSON["FirstPartialDataSet"]!["Shift"]!.ToString());
+            string Operator = JSON["FirstPartialDataSet"]!["Operator"]!.ToString();
+            FirstPartialDataSet = new PartialDataSet(Quantity, Shift, Operator);
+        }
+        if (Line.Contains("SecondPartialDataSet"))
+        {
+            int Quantity = int.Parse(JSON["SecondPartialDataSet"]!["Quantity"]!.ToString());
+            int Shift = int.Parse(JSON["SecondPartialDataSet"]!["Shift"]!.ToString());
+            string Operator = JSON["SecondPartialDataSet"]!["Operator"]!.ToString();
+            SecondPartialDataSet = new PartialDataSet(Quantity, Shift, Operator);
+        }
+        // construct the parsed PrintTicket
+        return new PrintTicket(Department, Process, Part, Mode, Number, Date, FirstPartialDataSet, SecondPartialDataSet);
     }
 
     /// <summary>

--- a/LotCoMPrinter/Models/Datasources/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicket.cs
@@ -12,37 +12,37 @@ namespace LotCoMPrinter.Models.Datasources;
 /// <param name="SerializationMode">The type of Serial Number used to Serialize this Print Ticket.</param>
 /// <param name="SerialNumber"></param>
 /// <param name="ProductionDate"></param>
-public partial class PrintTicket(Department Department, Process Process, Part Part, SerializationModes SerializationMode, string SerialNumber, Timestamp ProductionDate) : ObservableObject()
+public partial class PrintTicket(Department Department, Process Process, Part Part, SerializationModes SerializationMode, SerialNumber SerialNumber, Timestamp ProductionDate) : ObservableObject()
 {
     /// <summary>
     /// The Department that initiated this Print Ticket.
     /// </summary>
-    private Department Department = Department;
+    private readonly Department Department = Department;
 
     /// <summary>
     /// The Process that initiated this Print Ticket.
     /// </summary>
-    private Process Process = Process;
+    private readonly Process Process = Process;
 
     /// <summary>
     /// The Part that this Print Ticket is applied to.
     /// </summary>
-    private Part Part = Part;
+    private readonly Part Part = Part;
 
     /// <summary>
     /// The type of Serial Number used to Serialize this Print Ticket.
     /// </summary>
-    private SerializationModes SerializationMode = SerializationMode;
+    private readonly SerializationModes SerializationMode = SerializationMode;
 
     /// <summary>
     /// The Serial Number (JBK or Lot Number) applied to this Print Ticket.
     /// </summary>
-    private string SerialNumber = SerialNumber;
+    private readonly SerialNumber SerialNumber = SerialNumber;
 
     /// <summary>
     /// The Date and Time at which this Print Ticket was initiated.
     /// </summary>
-    private Timestamp ProductionDate = ProductionDate;
+    private readonly Timestamp ProductionDate = ProductionDate;
 
     private PartialDataSet? _firstPartialDataSet = null;
     /// <summary>

--- a/LotCoMPrinter/Models/Datasources/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicket.cs
@@ -169,35 +169,35 @@ public partial class PrintTicket(Department Department, Process Process, Part Pa
         // Department, Process, Part, SerializationMode, SerialNumber, and Production Date are all universal
         string JSON = 
             "{" +
-                "Department:{" +
-                    $"Title:{Department.Title}" +
+                "\"Department\":{" +
+                    $"\"Title\":\"{Department.Title}\"" +
                 "}," + 
-                "Process:{" +
-                    $"FullName:{Process.FullName}" +
+                "\"Process\":{" +
+                    $"\"FullName\":\"{Process.FullName}\"" +
                 "}," +
-                "Part:{" +
-                    $"PartNumber:{Part.PartNumber}" + 
+                "\"Part\":{" +
+                    $"\"PartNumber\":\"{Part.PartNumber}\"" + 
                 "}," +
-                $"SerializationMode:{ModeString}," +
-                $"SerialNumber:{SerialNumber.ToJSON()}," +
-                $"ProductionDate:{ProductionDate.Stamp}";
+                $"\"SerializationMode\":\"{ModeString}\"," +
+                $"\"SerialNumber\":\"{SerialNumber.ToJSON()}\"," +
+                $"\"ProductionDate\":\"{ProductionDate.Stamp}\"";
         // add partial data sets only if assigned
         if (HasFirstPartialDataSet)
         {
             JSON += 
-                ",FirstPartialDataSet:{" +
-                    $"Quantity:{FirstPartialDataSet!.Quantity}," +
-                    $"Shift:{FirstPartialDataSet!.Shift}," +
-                    $"Operator:{FirstPartialDataSet!.Operator}" +
+                ",\"FirstPartialDataSet\":{" +
+                    $"\"Quantity\":\"{FirstPartialDataSet!.Quantity}\"," +
+                    $"\"Shift\":\"{FirstPartialDataSet!.Shift}\"," +
+                    $"\"Operator\":\"{FirstPartialDataSet!.Operator}\"" +
                 "}";
         }
         if (HasSecondPartialDataSet)
         {
             JSON += 
-                ",SecondPartialDataSet:{" +
-                    $"Quantity:{SecondPartialDataSet!.Quantity}," +
-                    $"Shift:{SecondPartialDataSet!.Shift}," +
-                    $"Operator:{SecondPartialDataSet!.Operator}" +
+                ",\"SecondPartialDataSet\":{" +
+                    $"\"Quantity\":\"{SecondPartialDataSet!.Quantity}\"," +
+                    $"\"Shift\":\"{SecondPartialDataSet!.Shift}\"," +
+                    $"\"Operator\":\"{SecondPartialDataSet!.Operator}\"" +
                 "}";
         }
         // close the JSON stream

--- a/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
@@ -89,8 +89,12 @@ public static class PrintTicketCache
         {
             JSON = $"{JSON}{_ticket},";
         }
-        // remove trailing comma, close JSON stream, and write to the cache
-        JSON = JSON[..^1];
+        // check if tickets were added before removing the trailing comma
+        if (Tickets.Count > 0)
+        {
+            JSON = JSON[..^1];
+        }
+        // close JSON stream and write to the cache
         JSON = $"{JSON}]" + "}";
         await File.WriteAllTextAsync(CacheFile, JSON);
     }

--- a/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
@@ -1,0 +1,185 @@
+using Newtonsoft.Json;
+using Newtonsoft.Json.Linq;
+
+namespace LotCoMPrinter.Models.Datasources;
+
+public static class PrintTicketCache
+{
+    /// <summary>
+    /// The top directory of the Print Ticket cache file system.
+    /// </summary>
+    private static readonly string CacheDir = Path.Join(FileSystem.AppDataDirectory, "PrintTicketCache");
+
+    /// <summary>
+    /// The absolute path of the Print Ticket cache file.
+    /// </summary>
+    private static readonly string CacheFile = Path.Join(CacheDir, "ticket_cache.json");
+
+    /// <summary>
+    /// Reads the Print Ticket cache file and returns the results as a List of PrintTicket JSON streams.
+    /// </summary>
+    /// <returns>A List of JSON stream strings.</returns>
+    /// <exception cref="JsonReaderException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="JsonException"></exception>
+    private static async Task<List<string>> Read() 
+    {
+        // ensure that the cache file system exists
+        if (!Directory.Exists(CacheDir)) 
+        {
+            Directory.CreateDirectory(CacheDir);
+        }
+        if (!File.Exists(CacheFile)) 
+        {
+            File.Create(CacheFile).Close();
+            File.WriteAllText(CacheFile, "{Cache:[]}");
+        }
+        // read the cache and convert the JSON text to a List of strings
+        JObject JSON = JObject.Parse(await File.ReadAllTextAsync(CacheFile));
+        List<string>? Tickets;
+        try
+        {
+            Tickets = (List<string>)JsonConvert.DeserializeObject(JSON["Cache"]!.ToString())!;
+        }
+        catch
+        {
+            throw new JsonException("Failed to deserialize the cache file.");
+        }
+        return Tickets;
+    }
+
+    /// <summary>
+    /// Writes a List of PrintTicket objects to the cache file.
+    /// Converts Tickets to JSON streams to be written.
+    /// Slower than the alternative List of strings overload.
+    /// </summary>
+    /// <param name="Tickets"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    private static async Task Save(List<PrintTicket> Tickets) 
+    {
+        // convert the passed Print Tickets to JSON streams and write them to the cache
+        List<string> JSONTickets = Tickets
+            .Select(x => x
+            .ToJSON())
+            .ToList();
+        string JSON = "{Cache:[";
+        foreach (string _ticket in JSONTickets)
+        {
+            JSON = $"{JSON}{_ticket},";
+        }
+        // remove trailing comma, close JSON stream, and write to the cache
+        JSON = JSON[..^1];
+        JSON = $"{JSON}]" + "}";
+        await File.WriteAllTextAsync(CacheFile, JSON);
+    }
+
+    /// <summary>
+    /// Writes a List of PrintTickets, as JSON streams, to the cache file.
+    /// </summary>
+    /// <param name="Tickets"></param>
+    /// <returns></returns>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    private static async Task Save(List<string> Tickets) 
+    {
+        string JSON = "{Cache:[";
+        foreach (string _ticket in Tickets)
+        {
+            JSON = $"{JSON}{_ticket},";
+        }
+        // remove trailing comma, close JSON stream, and write to the cache
+        JSON = JSON[..^1];
+        JSON = $"{JSON}]" + "}";
+        await File.WriteAllTextAsync(CacheFile, JSON);
+    }
+
+    /// <summary>
+    /// Adds Ticket to the Print Ticket cache and saves to the cache file.
+    /// </summary>
+    /// <param name="Ticket"></param>
+    /// <returns></returns>
+    /// <exception cref="JsonReaderException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="JsonException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static async Task Cache(PrintTicket Ticket) 
+    {
+        // read the cache, convert Ticket to JSON and add it to the list, then write the list to the cache
+        List<string> JSON = await Read();
+        string TicketString = Ticket.ToJSON();
+        if (!JSON.Contains(TicketString))
+        {
+            JSON.Add(TicketString);
+        }
+        await Save(JSON);
+    }
+
+    /// <summary>
+    /// Removes Ticket from the Print Ticket cache, if it exists.
+    /// </summary>
+    /// <param name="Ticket"></param>
+    /// <returns></returns>
+    /// <exception cref="JsonReaderException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="JsonException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    public static async Task Remove(PrintTicket Ticket) 
+    {
+        // read the cache, convert Ticket to JSON and check for a match, remove any match, then write the list to the cache
+        List<string> JSON = await Read();
+        string TicketString = Ticket.ToJSON();
+        JSON.Remove(TicketString);
+        await Save(JSON);
+    }
+
+    /// <summary>
+    /// Returns the PrintTicket object at Index element of the cache file.
+    /// </summary>
+    /// <param name="Index"></param>
+    /// <returns>A single PrintTicket object found at Index in the cache.</returns>
+    /// <exception cref="JsonReaderException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="JsonException"></exception>
+    public static async Task<PrintTicket> GetPrintTicketAt(int Index)
+    {
+        // read the cache, confirm Index is in range and attempt to parse and return a PrintTicket object
+        List<string> JSON = await Read();
+        if (Index > JSON.Count)
+        {
+            throw new ArgumentOutOfRangeException($"The Index '{Index}' is outside the range of the cache file.");
+        }
+        try
+        {
+            return await PrintTicket.ParseJSON(JSON[Index]);
+        }
+        catch
+        {
+            throw new JsonException($"Failed to parse a PrintTicket from '{JSON[Index]}'.");
+        }
+    }
+
+    /// <summary>
+    /// Parses all PrintTickets in the cache and returns each as a PrintTicket object.
+    /// </summary>
+    /// <returns>A List of currently cached PrintTicket objects.</returns>
+    /// <exception cref="JsonReaderException"></exception>
+    /// <exception cref="OperationCanceledException"></exception>
+    /// <exception cref="JsonException"></exception>
+    /// <exception cref="ArgumentNullException"></exception>
+    /// <exception cref="ArgumentException"></exception>
+    public static async Task<List<PrintTicket>> GetAllPrintTickets()
+    {
+        // read the cache, convert every JSON stream to a PrintTicket, and return that List
+        List<string> JSON = await Read();
+        IEnumerable<Task<PrintTicket>> ParseTasks = JSON
+            .Select(PrintTicket.ParseJSON);
+        PrintTicket[] ParseResults = await Task.WhenAll(ParseTasks);
+        if (ParseResults is null)
+        {
+            return [];
+        }
+        return ParseResults.ToList();
+    }
+}

--- a/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
+++ b/LotCoMPrinter/Models/Datasources/PrintTicketCache.cs
@@ -32,7 +32,7 @@ public static class PrintTicketCache
         if (!File.Exists(CacheFile)) 
         {
             File.Create(CacheFile).Close();
-            File.WriteAllText(CacheFile, "{Cache:[]}");
+            File.WriteAllText(CacheFile, "{\"Cache\":[]}");
         }
         // read the cache and convert the JSON text to a List of strings
         JObject JSON = JObject.Parse(await File.ReadAllTextAsync(CacheFile));
@@ -146,7 +146,7 @@ public static class PrintTicketCache
     {
         // read the cache, confirm Index is in range and attempt to parse and return a PrintTicket object
         List<string> JSON = await Read();
-        if (Index > JSON.Count)
+        if (Index >= JSON.Count)
         {
             throw new ArgumentOutOfRangeException($"The Index '{Index}' is outside the range of the cache file.");
         }


### PR DESCRIPTION
# feature/146

## Addressed Feature Request
Resolves #146 

## Summary

The `PrintTicketCache` class provides caching functionality for `PrintTicket` objects.

## Rationale

This feature was implemented to support the Print Ticket system back-end. To allow users to open and manage multiple Tickets at once, there needs to be a way to consistently save and load local application instance Print Tickets. The `PrintTicketCache` class creates a system of `JSON` serialization/deserialization that will allow the Application's back-end to save and load previously opened but incomplete Print Tickets.

## Changes

#### `PrintTicket.cs`:
- Add `SerialNumber` class in place of `string` literals.
- Add `ToJSON()` and `ParseJSON()` methods:
  - Allow `JSON` serialization and deserialization of the class and its properties.

## New Classes

#### `PrintTicketCache.cs`:
Uses `JSON` serialization and deserialization to control the caching and loading of `PrintTicket` objects in Program Data.
- `CacheDir` property sets the top directory of the Print Ticket cache file system.
- `CacheFile` property sets the absolute path of the Print Ticket cache file.
- `Read()` method reads the Print Ticket cache file and returns the results as a List of `PrintTicket` JSON streams.
- `Save()` method writes a List of `PrintTicket` objects or `strings` to the cache file.
- `Cache()` method adds a `PrintTicket` object to the Print Ticket cache and saves to the cache file.
- `Remove()` method removes a `PrintTicket` from the Print Ticket cache, if it exists.
- `GetPrintTicketAt()` method returns the `PrintTicket` object at an index element of the cache file.
- `GetAllPrintTickets()` method parses all `PrintTicket` objects in the cache.

## Impact

The implementation of the `PrintTicketCache` class improves the Print Ticket back-end by providing a method for saving and loading in-progress `PrintTicket` objects. It will provide integral functionality to the UI where users can load and save Print Tickets for later, a very common situation.

Additionally, tweaks to the `PrintTicket` class improve clarity by removing reliance on `string` literal values for the `SerialNumber` property. Now, the property uses the `SerialNumber` class which has much better control and provides more powerful functionality. It also interfaces with the project much better. 

## Checklist

- [x] Code follows the project's coding standards

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>