### PR TITLE
feature/156

### DIFF
--- a/LotCoMPrinter/Models/Datasources/BasketLabel.cs
+++ b/LotCoMPrinter/Models/Datasources/BasketLabel.cs
@@ -21,7 +21,7 @@ public partial class BasketLabel : Label
             HeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
             HeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin - 28,
             SubHeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
-            SubHeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin + LabelDimensions.TextSizes.Large,
+            SubHeadingVerticalAnchor: (LabelDimensions.PaddingLevels.Wide * 2) + LabelDimensions.TextSizes.Large,
             BodyTitleHorizontalAnchor: LabelDimensions.PaddingLevels.Thin,
             BodyTitleVerticalAnchor: LabelDimensions.CodeSizes.Default,
             CodeHorizontalAnchor: LabelDimensions.LabelSizes.Default - LabelDimensions.CodeSizes.Default - LabelDimensions.PaddingLevels.Thin,

--- a/LotCoMPrinter/Models/Datasources/BasketLabel.cs
+++ b/LotCoMPrinter/Models/Datasources/BasketLabel.cs
@@ -12,20 +12,22 @@ public partial class BasketLabel : Label
     (
         new LabelDimensions
         (
-            LabelDimensions.LabelSizes.Default,
-            LabelDimensions.CodeSizes.Default,
-            LabelDimensions.TextSizes.Tiny,
-            LabelDimensions.TextSizes.Small,
-            LabelDimensions.TextSizes.Large,
-            LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.PaddingLevels.Thin - 56,
-            LabelDimensions.PaddingLevels.Thin - 28,
-            LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.CodeSizes.Default,
-            LabelDimensions.LabelSizes.Default - LabelDimensions.CodeSizes.Default - LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.PaddingLevels.Thin * 2,
-            LabelDimensions.CodeSizes.Default + LabelDimensions.TextSizes.Small + (LabelDimensions.PaddingLevels.Thin * 4)
+            Dimension: LabelDimensions.LabelSizes.Default,
+            CodeDimension: LabelDimensions.CodeSizes.Default,
+            TextSizeSmall: LabelDimensions.TextSizes.Tiny,
+            TextSizeMedium: LabelDimensions.TextSizes.Small,
+            TextSizeLarge: LabelDimensions.TextSizes.Large,
+            InternalPadding: LabelDimensions.PaddingLevels.Thin,
+            HeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
+            HeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin - 28,
+            SubHeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
+            SubHeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin + LabelDimensions.TextSizes.Large,
+            BodyTitleHorizontalAnchor: LabelDimensions.PaddingLevels.Thin,
+            BodyTitleVerticalAnchor: LabelDimensions.CodeSizes.Default,
+            CodeHorizontalAnchor: LabelDimensions.LabelSizes.Default - LabelDimensions.CodeSizes.Default - LabelDimensions.PaddingLevels.Thin,
+            CodeVerticalAnchor: LabelDimensions.PaddingLevels.Thin,
+            BodyHorizontalAnchor: LabelDimensions.PaddingLevels.Thin * 2,
+            BodyVerticalAnchor: LabelDimensions.CodeSizes.Default + LabelDimensions.TextSizes.Small + (LabelDimensions.PaddingLevels.Thin * 4)
         )
     )
     {

--- a/LotCoMPrinter/Models/Datasources/Label.cs
+++ b/LotCoMPrinter/Models/Datasources/Label.cs
@@ -139,24 +139,27 @@ public class Label
             Surface.PixelOffsetMode = PixelOffsetMode.HighQuality;
             Surface.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
             // draw the Heading text
-            Surface.DrawString(HeadingText, FontLarge!, Brushes.Black, Dimensions.HeadingHorizontalAnchor, Dimensions.HeadingVerticalAnchor);
+            Surface.DrawString
+            (
+                HeadingText,
+                FontLarge!,
+                Brushes.Black,
+                Dimensions.HeadingHorizontalAnchor,
+                Dimensions.HeadingVerticalAnchor
+            );
             Surface.Flush();
         });
     }
 
-    /// <summary>
-    /// Writes PartName text to the Label using the configured Part Name Anchors.
-    /// </summary>
-    /// <param name="PartName"></param>
-    /// <returns></returns>
-    public async Task AddPartNameAsync(string PartName) 
+
+    public async Task AddSubHeadingAsync(string SubHeadingText)
     {
-        // start a new CPU thread to apply the part name to the Label Base
+        // start a new CPU thread to apply the Sub-heading to the Label Base
         await Task.Run(() => 
         {
             if (Image is null)
             {
-                throw new NullReferenceException("Cannot apply a Part Name to a blank Label.");
+                throw new NullReferenceException("Cannot apply a Sub-Heading to a blank Label.");
             }
             // create a drawing surface to draw the text with
             Graphics Surface = Graphics.FromImage(Image);
@@ -165,8 +168,49 @@ public class Label
             Surface.InterpolationMode = InterpolationMode.HighQualityBicubic;
             Surface.PixelOffsetMode = PixelOffsetMode.HighQuality;
             Surface.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
-            // draw the Part Name text
-            Surface.DrawString(PartName, FontMedium!, Brushes.Black, Dimensions.PartNameHorizontalAnchor, Dimensions.PartNameVerticalAnchor);
+            // draw the Heading text
+            Surface.DrawString
+            (
+                SubHeadingText,
+                FontLarge!,
+                Brushes.Black,
+                Dimensions.SubHeadingHorizontalAnchor,
+                Dimensions.SubHeadingVerticalAnchor
+            );
+            Surface.Flush();
+        });
+    }
+
+    /// <summary>
+    /// Writes Body Title text to the Label using the configured Body Title Anchors.
+    /// </summary>
+    /// <param name="Text"></param>
+    /// <returns></returns>
+    public async Task AddBodyTitleAsync(string Text)
+    {
+        // start a new CPU thread to apply the Body Title to the Label Base
+        await Task.Run(() =>
+        {
+            if (Image is null)
+            {
+                throw new NullReferenceException("Cannot apply a Body Title to a blank Label.");
+            }
+            // create a drawing surface to draw the text with
+            Graphics Surface = Graphics.FromImage(Image);
+            // set the quality properties of the Surface
+            Surface.SmoothingMode = SmoothingMode.AntiAlias;
+            Surface.InterpolationMode = InterpolationMode.HighQualityBicubic;
+            Surface.PixelOffsetMode = PixelOffsetMode.HighQuality;
+            Surface.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
+            // draw the Body Title text
+            Surface.DrawString
+            (
+                Text,
+                FontMedium!,
+                Brushes.Black,
+                Dimensions.BodyTitleHorizontalAnchor,
+                Dimensions.BodyTitleVerticalAnchor
+            );
             Surface.Flush();
         });
     }
@@ -194,8 +238,18 @@ public class Label
             Surface.InterpolationMode = InterpolationMode.HighQualityBicubic;
             Surface.PixelOffsetMode = PixelOffsetMode.HighQuality;
             // resize and draw the QR Code
-            Bitmap LabelCodeImage = Resizer.ResizeImage(LabelCode.Code!, Dimensions.CodeDimension, Dimensions.CodeDimension);
-            Surface.DrawImage(LabelCodeImage, Dimensions.CodeHorizontalAnchor, Dimensions.CodeVerticalAnchor);
+            Bitmap LabelCodeImage = Resizer.ResizeImage
+            (
+                LabelCode.Code!,
+                Dimensions.CodeDimension,
+                Dimensions.CodeDimension
+            );
+            Surface.DrawImage
+            (
+                LabelCodeImage,
+                Dimensions.CodeHorizontalAnchor,
+                Dimensions.CodeVerticalAnchor
+            );
             Surface.Flush();
         });
     }
@@ -237,7 +291,14 @@ public class Label
             Surface.PixelOffsetMode = PixelOffsetMode.HighQuality;
             Surface.TextRenderingHint = TextRenderingHint.AntiAliasGridFit;
             // draw the Heading text
-            Surface.DrawString(LabelFieldsBody, FontSmall!, Brushes.Black, Dimensions.BodyHorizontalAnchor, Dimensions.BodyVerticalAnchor);
+            Surface.DrawString
+            (
+                LabelFieldsBody,
+                FontSmall!,
+                Brushes.Black,
+                Dimensions.BodyHorizontalAnchor,
+                Dimensions.BodyVerticalAnchor
+            );
             Surface.Flush();
         });
     }

--- a/LotCoMPrinter/Models/Datasources/LabelDimensions.cs
+++ b/LotCoMPrinter/Models/Datasources/LabelDimensions.cs
@@ -89,16 +89,28 @@ public class LabelDimensions
     /// The vertical position of the Label's Heading text.
     /// </summary>
     public int HeadingVerticalAnchor;
-    
-    /// <summary>
-    /// The horizontal position of the Label's Part Name text.
-    /// </summary>
-    public int PartNameHorizontalAnchor;
 
     /// <summary>
-    /// The vertical position of the Label's Part Name text.
+    /// The horizontal position of the Label's Sub-Heading text.
+    /// This text is the same size as the Heading text.
     /// </summary>
-    public int PartNameVerticalAnchor;
+    public int SubHeadingHorizontalAnchor;
+
+    /// <summary>
+    /// The vertical position of the Label's Sub-Heading text.
+    /// This text is the same size as the Heading text.
+    /// </summary>
+    public int SubHeadingVerticalAnchor;
+
+    /// <summary>
+    /// The horizontal position of the Label's Body Title text.
+    /// </summary>
+    public int BodyTitleHorizontalAnchor;
+    
+    /// <summary>
+    /// The vertical position of the Label's Body Title text.
+    /// </summary>
+    public int BodyTitleVerticalAnchor;
     
     /// <summary>
     /// The horizontal (left) position of the QR Code on the Label.
@@ -137,8 +149,10 @@ public class LabelDimensions
         InternalPadding = Convert.ToInt32(InternalPadding * DpiScale);
         HeadingHorizontalAnchor = Convert.ToInt32(HeadingHorizontalAnchor * DpiScale);
         HeadingVerticalAnchor = Convert.ToInt32(HeadingVerticalAnchor * DpiScale);
-        PartNameHorizontalAnchor = Convert.ToInt32(PartNameHorizontalAnchor * DpiScale);
-        PartNameVerticalAnchor = Convert.ToInt32(PartNameVerticalAnchor * DpiScale);
+        SubHeadingHorizontalAnchor = Convert.ToInt32(SubHeadingHorizontalAnchor * DpiScale);
+        SubHeadingVerticalAnchor = Convert.ToInt32(SubHeadingVerticalAnchor * DpiScale);
+        BodyTitleHorizontalAnchor = Convert.ToInt32(BodyTitleHorizontalAnchor * DpiScale);
+        BodyTitleVerticalAnchor = Convert.ToInt32(BodyTitleVerticalAnchor * DpiScale);
         CodeHorizontalAnchor = Convert.ToInt32(CodeHorizontalAnchor * DpiScale);
         CodeVerticalAnchor = Convert.ToInt32(CodeVerticalAnchor * DpiScale);
         BodyHorizontalAnchor = Convert.ToInt32(BodyHorizontalAnchor * DpiScale);
@@ -162,7 +176,7 @@ public class LabelDimensions
     /// <param name="CodeVerticalAnchor">The vertical (top) position of the QR Code on the Label.</param>
     /// <param name="BodyHorizontalAnchor">The horizontal position of the Label's Data Fields text.</param>
     /// <param name="BodyVerticalAnchor">The vertical position of the Label's Data Fields text.</param>
-    public LabelDimensions(int? Dimension, int? CodeDimension, int? TextSizeSmall, int? TextSizeMedium, int? TextSizeLarge, int? InternalPadding, int HeadingHorizontalAnchor, int HeadingVerticalAnchor, int PartNameHorizontalAnchor, int PartNameVerticalAnchor, int CodeHorizontalAnchor, int CodeVerticalAnchor, int BodyHorizontalAnchor, int BodyVerticalAnchor)
+    public LabelDimensions(int? Dimension, int? CodeDimension, int? TextSizeSmall, int? TextSizeMedium, int? TextSizeLarge, int? InternalPadding, int HeadingHorizontalAnchor, int HeadingVerticalAnchor, int SubHeadingHorizontalAnchor, int SubHeadingVerticalAnchor, int BodyTitleHorizontalAnchor, int BodyTitleVerticalAnchor, int CodeHorizontalAnchor, int CodeVerticalAnchor, int BodyHorizontalAnchor, int BodyVerticalAnchor)
     {
         if (Dimension is not null)
         {
@@ -190,8 +204,10 @@ public class LabelDimensions
         }
         this.HeadingHorizontalAnchor = HeadingHorizontalAnchor;
         this.HeadingVerticalAnchor = HeadingVerticalAnchor;
-        this.PartNameHorizontalAnchor = PartNameHorizontalAnchor; 
-        this.PartNameVerticalAnchor = PartNameVerticalAnchor;
+        this.SubHeadingHorizontalAnchor = SubHeadingHorizontalAnchor;
+        this.SubHeadingVerticalAnchor = SubHeadingVerticalAnchor;
+        this.BodyTitleHorizontalAnchor = BodyTitleHorizontalAnchor; 
+        this.BodyTitleVerticalAnchor = BodyTitleVerticalAnchor;
         this.CodeHorizontalAnchor = CodeHorizontalAnchor; 
         this.CodeVerticalAnchor = CodeVerticalAnchor;
         this.BodyHorizontalAnchor = BodyHorizontalAnchor;

--- a/LotCoMPrinter/Models/Datasources/LabelGenerator.cs
+++ b/LotCoMPrinter/Models/Datasources/LabelGenerator.cs
@@ -100,7 +100,7 @@ public static class LabelGenerator
             }
             // add the remaining required fields and return the body text
             Body.Add($"Date: {new Timestamp(Ticket.ProductionDate).Stamp}");
-            Body.Add($"Shift: {Ticket.ProductionShift}");
+            Body.Add($"Shift: {ShiftExtensions.ToString(Ticket.ProductionShift)}");
             return Body;
         });
     }
@@ -129,7 +129,7 @@ public static class LabelGenerator
         List<string> Body = await GenerateBody(Ticket);
         // apply the header, the QR Code, and the Label Data to the Label
         await Label.AddHeaderAsync(Ticket.SerialNumber.GetFormattedValue());
-        await Label.AddPartNameAsync(Ticket.Part.PartName);
+        await Label.AddPartNameAsync($"{Ticket.Part.ModelNumber.Code} {Ticket.Part.PartName}");
         await Label.AddQRCodeAsync(Code);
         await Label.AddBodyTextAsync(Body);
         // return the Label image

--- a/LotCoMPrinter/Models/Datasources/LabelGenerator.cs
+++ b/LotCoMPrinter/Models/Datasources/LabelGenerator.cs
@@ -129,7 +129,8 @@ public static class LabelGenerator
         List<string> Body = await GenerateBody(Ticket);
         // apply the header, the QR Code, and the Label Data to the Label
         await Label.AddHeaderAsync(Ticket.SerialNumber.GetFormattedValue());
-        await Label.AddPartNameAsync($"{Ticket.Part.ModelNumber.Code} {Ticket.Part.PartName}");
+        await Label.AddSubHeadingAsync(Ticket.Part.ModelNumber.Code);
+        await Label.AddBodyTitleAsync(Ticket.Part.PartName);
         await Label.AddQRCodeAsync(Code);
         await Label.AddBodyTextAsync(Body);
         // return the Label image

--- a/LotCoMPrinter/Models/Datasources/PartialDataSetLabel.cs
+++ b/LotCoMPrinter/Models/Datasources/PartialDataSetLabel.cs
@@ -12,20 +12,22 @@ public partial class PartialDataSetLabel : Label
     (
         new LabelDimensions
         (
-            LabelDimensions.LabelSizes.Default,
-            LabelDimensions.CodeSizes.Default,
-            LabelDimensions.TextSizes.Tiny,
-            LabelDimensions.TextSizes.Small,
-            LabelDimensions.TextSizes.Medium,
-            LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.PaddingLevels.Thin - 56,
-            LabelDimensions.PaddingLevels.Thin - 56,
-            LabelDimensions.PaddingLevels.Thin,
-            LabelDimensions.PaddingLevels.Thin - 56 + (LabelDimensions.TextSizes.Medium * 2) + LabelDimensions.PaddingLevels.Thin,
-            0, // no QR Codes
-            0, // no QR Codes
-            LabelDimensions.PaddingLevels.Thin * 2,
-            LabelDimensions.TextSizes.Medium + LabelDimensions.TextSizes.Small + (LabelDimensions.PaddingLevels.Thin * 4)
+            Dimension: LabelDimensions.LabelSizes.Default,
+            CodeDimension: LabelDimensions.CodeSizes.Default,
+            TextSizeSmall: LabelDimensions.TextSizes.Tiny,
+            TextSizeMedium: LabelDimensions.TextSizes.Small,
+            TextSizeLarge: LabelDimensions.TextSizes.Medium,
+            InternalPadding: LabelDimensions.PaddingLevels.Thin,
+            HeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
+            HeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
+            SubHeadingHorizontalAnchor: LabelDimensions.PaddingLevels.Thin - 56,
+            SubHeadingVerticalAnchor: LabelDimensions.PaddingLevels.Thin + LabelDimensions.TextSizes.Large,
+            BodyTitleHorizontalAnchor: LabelDimensions.PaddingLevels.Thin,
+            BodyTitleVerticalAnchor: LabelDimensions.PaddingLevels.Thin - 56 + (LabelDimensions.TextSizes.Medium * 2) + LabelDimensions.PaddingLevels.Thin,
+            CodeHorizontalAnchor: 0, // no QR Codes
+            CodeVerticalAnchor: 0, // no QR Codes
+            BodyHorizontalAnchor: LabelDimensions.PaddingLevels.Thin * 2,
+            BodyVerticalAnchor: LabelDimensions.TextSizes.Medium + LabelDimensions.TextSizes.Small + (LabelDimensions.PaddingLevels.Thin * 4)
         )
     )
     {


### PR DESCRIPTION
# feature/156

## Addressed Feature Request
Resolves #156 

## Summary

Several project members have requested that the Model Code is added to the Part Name on the Subtitle of Basket Labels. This aims to reduce ambiguity between parts that have very basic names like "Cover" that is shared between several parts.

## Rationale

Adding the `ModelNumber` Code to the Part Name on Basket Labels grants viewers the ability to immediately identify the Parts in that basket.

## Changes

#### `Label.cs`:
- Add `AddSubHeadingAsync()` method:
  - Allows for the addition of a Sub-heading text to a Label object.
- Refactor `AddBodyTitleAsync()` method:
  - Rename from `AddPartNameAsync()`;
  - Use `BodyTitleHorizontalAnchor` and `BodyTitleVerticalAnchor` properties to position.
- Refactor `AdjustScale()` method:
  - Add `SubHeadingHorizontalAnchor`, `SubHeadingVerticalAnchor`, `BodyTitleHorizontalAnchor` and `BodyTitleVerticalAnchor` properties to adjusted list.
- Refactor `.ctor`:
  - Implement new anchor properties.

#### `BasketLabel.cs`:
- Refactor `Dimensions` definition:
  - Add `SubHeading` and `BodyTitle` anchor definitions;
  - Add property names to property definitions for clarity.

#### `PartialDataSetLabel.cs`:
- Refactor `Dimensions` definition:
  - Add `SubHeading` and `BodyTitle` anchor definitions;
  - Add property names to property definitions for clarity.

#### `LabelGenerator.cs`:
- Add call of `AddSubHeadingAsync()`:
  - Adds `Part.ModelNumber.Code` as the Sub-Heading of the Label.
- Refactor `GenerateBody()` method: 
  - Use the literal assigned to the `enum` value of `ProductionShift` (1, 2, 3).
- Refactor `GenerateLabelAsync()` method:
  - Add a reference to `Part.ModelCode.Code` in the `string` passed to `AddPartNameAsync()`.

## Impact

This feature does not significantly impact the functionality of the application, but it does improve the physical intractability of the system.

## Checklist

- [x] Code follows the project's coding standards

- [x] The documentation has been updated to reflect the new feature

## Additional Notes