### PR TITLE
bug/158

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/LabelPrintJob.cs
+++ b/LotCoMPrinter/Models/Datatypes/LabelPrintJob.cs
@@ -50,12 +50,13 @@ public class LabelPrintJob(PrintTicket Ticket)
     /// <exception cref="PrintRequestException"></exception>
     public async Task<bool> Run() 
     {
-        // generate a Label from the saved PrintTicket
-        try 
+        // set the final ProductionDate and generate a Label from the saved PrintTicket
+        Ticket.ProductionDate = DateTime.Now;
+        try
         {
             await GenerateLabelImage();
-        } 
-        catch (LabelBuildException _ex) 
+        }
+        catch (LabelBuildException _ex)
         {
             throw new LabelBuildException(_ex.Message);
         }

--- a/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
+++ b/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
@@ -54,7 +54,7 @@ public partial class NewPrintTicketFormViewModel : ObservableObject
         }
     }
 
-    private DateTime _productionDate = DateTime.Today;
+    private DateTime _productionDate = DateTime.Now;
     /// <summary>
     /// The Date and Time at which this Form was initiated.
     /// </summary>    
@@ -202,7 +202,7 @@ public partial class NewPrintTicketFormViewModel : ObservableObject
         {
             throw new SerializationException("Failed to retrieve a Serial Number for the new Print Ticket.");
         }
-        PrintTicket NewTicket = new PrintTicket(Process, Part, Process.Serialization, TicketNumber, ProductionDate, (Shift)ProductionShift, 0, ProductionOperator, new VariableFieldSet());
+        PrintTicket NewTicket = new PrintTicket(Process, Part, Process.Serialization, TicketNumber, DateTime.Now, (Shift)ProductionShift, 0, ProductionOperator, new VariableFieldSet());
         // apply the SerialNumber to the appropriate field and return the new Ticket
         if (NewTicket.SerializationMode == SerializationMode.JBK)
         {

--- a/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
+++ b/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
@@ -169,7 +169,7 @@ public partial class NewPrintTicketFormViewModel : ObservableObject
         {
             _allProcesses = value;
             OnPropertyChanged(nameof(_allProcesses));
-            OnPropertyChanged(nameof(_allProcesses));
+            OnPropertyChanged(nameof(AllProcesses));
         }
     }
 

--- a/LotCoMPrinter/Views/NewPrintTicketForm.xaml
+++ b/LotCoMPrinter/Views/NewPrintTicketForm.xaml
@@ -206,6 +206,7 @@
                         StrokeShape="RoundRectangle 10,10,10,10">
                         <DatePicker
                             x:Name="ProductionDatePicker"
+                            IsEnabled="False"
                             WidthRequest="120"
                             Date="{Binding ProductionDate}"/>
                     </Border>


### PR DESCRIPTION
# bug/158

## Addressed Bug Report
Resolves #158 

## Summary

The timestamp on printed Labels is always "00:00:00" instead of the timestamp at which the Label was actually printed.

## Root Cause(s)/Faults

The cause of this issue was the incorrect use of the `DateTime` class' `Today` property. This property only provides the current `MM/dd/yyyy` of the Date and defaults the `HH:mm:ss` section to "00:00:00."

## Rationale

The chosen solution ensures that an accurate `ProductionDate` is set at instantiation of the `PrintTicket`. It also ensures that `PrintTicket`'s `ProductionDate` will not be changed until Printing occurs, at which time `ProductionDate` is refreshed so that the printed Label has the exact timestamp of the print action.

## Changes

#### `LabelPrintJob.cs`:
- Refactor `Run()` method:
  - Update the `ProductionDate` property of the `PrintTicket` object in the `Ticket` property when started.

#### `NewPrintTicketFormViewModel.cs`:
- Refactor `ProductionDate` property:
  - Use `DateTime.Now` instead of `DateTime.Today` to initialize property.
- Refactor `AllProcesses` setter:
  - Remove duplicated invocation of `OnPropertyChanged(nameof(_allProcesses))`;
  - Add invocation of `OnPropertyChanged(nameof(AllProcesses))`.
- Refactor `OpenNewPrintTicket()` method:
  - Pass `DateTime.Now` as the `ProductionDate` argument of the `PrintTicket.ctor()` method.

#### `NewPrintTicketForm.xaml`:
- Refactor `ProductionDatePicker` control:
  - Disable control by default.

## Impact

With these changes, the Production Date of Printed Labels will always be set to the Date and Time of the print action. Additionally, the `PrintTicket.ProductionDate` property is more protected throughout the creation and editing processes, aiding in Ticket Date management.

## Checklist

- [x] Code follows the project's coding standards

- [x] The solution thoroughly and effectively addresses the root cause mentioned above

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>