### PR TITLE
feature/163

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -173,6 +173,36 @@ public partial class PrintTicket : ObservableObject
         }
     }
 
+    private bool _jbkManualEntry = false;
+    /// <summary>
+    /// Whether this PrintTicket can accept a manually-entered JBK Number or not.
+    /// </summary>
+    public bool JBKManualEntry
+    {
+        get { return _jbkManualEntry; }
+        set
+        {
+            _jbkManualEntry = value;
+            OnPropertyChanged(nameof(_jbkManualEntry));
+            OnPropertyChanged(nameof(JBKManualEntry));
+        }
+    }
+
+    private bool _lotManualEntry = false;
+    /// <summary>
+    /// Whether this PrintTicket can accept a manually-entered Lot Number or not.
+    /// </summary>
+    public bool LotManualEntry
+    {
+        get { return _lotManualEntry; }
+        set
+        {
+            _lotManualEntry = value;
+            OnPropertyChanged(nameof(_lotManualEntry));
+            OnPropertyChanged(nameof(LotManualEntry));
+        }
+    }
+
     /// <summary>
     /// Returns whether the Print Ticket has one Partial Data Set associated with it.
     /// </summary>
@@ -259,6 +289,14 @@ public partial class PrintTicket : ObservableObject
         Title = $"{Part.ModelNumber.Code} {Part.PartName} - {SerialNumber.GetFormattedValue()}";
         IsPassThrough = _process.Type == OriginationType.PassThrough;
         ProductionDateNoTime = $"{ProductionDate.Month}/{ProductionDate.Day}/{ProductionDate.Year}";
+        if (Process.RequiredFields.JBKNumber && SerializationMode != SerializationMode.JBK)
+        {
+            JBKManualEntry = true;
+        }
+        if (Process.RequiredFields.LotNumber && SerializationMode != SerializationMode.Lot)
+        {
+            LotManualEntry = true;
+        }
     }
 
     /// <summary>

--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -234,10 +234,10 @@ public partial class PrintTicket : ObservableObject
     public partial bool IsPassThrough { get; set; }
 
     /// <summary>
-    /// Returns the Production Date without the Time segment.
+    /// Returns the Production Date without the Year or Time segment.
     /// </summary>
     [ObservableProperty]
-    public partial string ProductionDateNoTime { get; set; }
+    public partial string ProductionDateShort { get; set; }
 
     /// <summary>
     /// Controls whether the Print Ticket is selected in the Open Print Ticket ListView.
@@ -288,7 +288,7 @@ public partial class PrintTicket : ObservableObject
         HasSpace = !(HasFirstPartialDataSet && HasSecondPartialDataSet);
         Title = $"{Part.ModelNumber.Code} {Part.PartName} - {SerialNumber.GetFormattedValue()}";
         IsPassThrough = _process.Type == OriginationType.PassThrough;
-        ProductionDateNoTime = $"{ProductionDate.Month}/{ProductionDate.Day}/{ProductionDate.Year}";
+        ProductionDateShort = $"{ProductionDate.Month}/{ProductionDate.Day}";
         if (Process.RequiredFields.JBKNumber && SerializationMode != SerializationMode.JBK)
         {
             JBKManualEntry = true;

--- a/LotCoMPrinter/Models/Services/LabelGenerator.cs
+++ b/LotCoMPrinter/Models/Services/LabelGenerator.cs
@@ -1,4 +1,5 @@
 using LotCoMPrinter.Models.Datatypes;
+using LotCoMPrinter.Models.Enums;
 using LotCoMPrinter.Models.Exceptions;
 using LotCoMPrinter.Models.Extensions;
 
@@ -130,7 +131,14 @@ public static class LabelGenerator
         QRCode? Code = await GenerateCode(Ticket);
         List<string> Body = await GenerateBody(Ticket);
         // apply the header, the QR Code, and the Label Data to the Label
-        await Label.AddHeaderAsync(Ticket.SerialNumber.GetFormattedValue());
+        if (Ticket.SerializationMode == SerializationMode.Lot)
+        {
+            await Label.AddHeaderAsync(Ticket.ProductionDateShort);
+        }
+        else
+        {
+            await Label.AddHeaderAsync(Ticket.SerialNumber.GetFormattedValue());
+        }
         await Label.AddSubHeadingAsync(Ticket.Part.ModelNumber.Code);
         await Label.AddBodyTitleAsync(Ticket.Part.PartName);
         await Label.AddQRCodeAsync(Code);

--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -652,9 +652,9 @@
                                 StrokeShape="RoundRectangle 10,10,10,10">
                                 <Entry
                                     x:Name="JBKNumberEntry"
-                                    IsEnabled="{Binding ActiveTicket.Untracked.IsPassThrough}"
+                                    IsEnabled="{Binding ActiveTicket.Untracked.JBKManualEntry}"
                                     Text="{Binding ActiveTicket.Tracked.VariableFields.JBKNumber.Formatted}"
-                                    TextChanged="OnVariableFieldSetEntryTextChanged"
+                                    Unfocused="OnSerialNumberEntryUnfocused"
                                     MaxLength="3"/>
                             </Border>
                         </HorizontalStackLayout>
@@ -682,9 +682,9 @@
                                 StrokeShape="RoundRectangle 10,10,10,10">
                                 <Entry
                                     x:Name="LotNumberEntry"
-                                    IsEnabled="{Binding ActiveTicket.Untracked.IsPassThrough}"
+                                    IsEnabled="{Binding ActiveTicket.Untracked.LotManualEntry}"
                                     Text="{Binding ActiveTicket.Tracked.VariableFields.LotNumber.Formatted}"
-                                    TextChanged="OnVariableFieldSetEntryTextChanged"
+                                    Unfocused="OnSerialNumberEntryUnfocused"
                                     MaxLength="9"/>
                             </Border>
                         </HorizontalStackLayout>

--- a/LotCoMPrinter/Views/MainPage.xaml.cs
+++ b/LotCoMPrinter/Views/MainPage.xaml.cs
@@ -460,7 +460,7 @@ public partial class MainPage : ContentPage
 		{
 			try
 			{
-				ViewModel.ActiveTicket.Tracked.VariableFields.JBKNumber = new JBKNumber(int.Parse(e.NewTextValue));
+				new JBKNumber(int.Parse(e.NewTextValue));
 				JBKNumberControl.Stroke = Grey500;
 			}
 			catch
@@ -473,7 +473,7 @@ public partial class MainPage : ContentPage
 		{
 			try
 			{
-				ViewModel.ActiveTicket.Tracked.VariableFields.LotNumber = new LotNumber(int.Parse(e.NewTextValue));
+				new LotNumber(int.Parse(e.NewTextValue));
 				LotNumberControl.Stroke = Grey500;
 			}
 			catch
@@ -531,6 +531,54 @@ public partial class MainPage : ContentPage
 			catch
 			{
 				HeatNumberControl.Stroke = Colors.Red;
+			}
+		}
+	}
+
+	/// <summary>
+	/// Handler for the Unfocused event from the JBKNumberEntry or LotNumberEntry controls.
+	/// </summary>
+	/// <param name="sender"></param>
+	/// <param name="e"></param>
+	private void OnSerialNumberEntryUnfocused(object sender, EventArgs e)
+	{
+		if (ViewModel.ActiveTicket is null)
+		{
+			return;
+		}
+		Entry Sender = (Entry)sender;
+		// JBK Number was unfocused
+		if (sender.Equals(JBKNumberEntry))
+		{
+			if (Sender.Text is null || Sender.Text.Equals(""))
+			{
+				JBKNumberControl.Stroke = Colors.Red;
+			}
+			try
+			{
+				ViewModel.ActiveTicket!.Tracked.VariableFields.JBKNumber = new JBKNumber(int.Parse(Sender.Text!));
+				JBKNumberControl.Stroke = Grey500;
+			}
+			catch
+			{
+				JBKNumberControl.Stroke = Colors.Red;
+			}
+		}
+		// Lot Number was unfocused
+		if (sender.Equals(LotNumberEntry))
+		{
+			if (Sender.Text is null || Sender.Text.Equals(""))
+			{
+				LotNumberControl.Stroke = Colors.Red;
+			}
+			try
+			{
+				ViewModel.ActiveTicket!.Tracked.VariableFields.LotNumber = new LotNumber(int.Parse(Sender.Text!));
+				LotNumberControl.Stroke = Grey500;
+			}
+			catch
+			{
+				LotNumberControl.Stroke = Colors.Red;
 			}
 		}
 	}


### PR DESCRIPTION
# feature/163

## Addressed Feature Request
Resolves #163 

## Summary

**Briefly describe the feature being introduced.**

This PR adds the ability for operators to enter both JBK and Lot Numbers.

Additionally, a minor change has been implemented to write the Date on the Header of Labels serialized by Lot Numbers. 

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

There is a small number of Processes that require both JBK and Lot Number, despite being serialized by only Lot Number. Prior to this PR, the application would lock the JBK Number `Entry` with no text because the Process was not marked as `Pass-through` and, assumedly, would have a JBK auto-assigned. This made it impossible to print Labels for these Processes, as the required `JBKNumber` field could not be entered, causing a validation failure.

Placing the Date on Lot-serialized Labels matches the physical system currently in place. It also addresses a problem where Lot Numbers would run off of the right-end of the Label due to their length.

## Changes

**List the major changes made in this pull request.**

#### `PrintTicket.cs`:
- Add `JBKManualEntry` and `LotManualEntry` binding properties:
  - Configured at instantiation to allow entry of a JBK Number or a Lot Number on a Process that requires both.

#### `LabelGenerator.cs`:
- Refactor `GenerateLabelAsync()` method:
  - Implement logic to either engrave the JBK Number or the Production Date on the Header of a `BasketLabel`.

#### `MainPage.xaml.cs`: 
- Add `OnSerialNumberEntryUnfocused()` event handler: 
  - Confirms that the text left in the sending `Entry` is valid and makes the `Entry`'s border red if not.
- Refactor `OnVariableFieldSetEntryTextChanged()` event handler:
  - Remove the immediate conversion to `JBKNumber` or `LotNumber` objects, which was making it impossible to enter numbers other than "001"-"009"/"000000001"-"000000009".

#### `MainPage.xaml`:
- Refactor bindings:
  - Bind `JBKNumberEntry` and `LotNumberEntry` to a new event handler that confirms the validity of the data entered in the `Entry`.

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

It is now possible to print Labels for Processes that require both of the Serialization data fields. This change could potentially create validation issues, so that is something to keep an eye out for in testing and implementation.

## Checklist

- [x] Code follows the project's coding standards

- [x] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>