### PR TITLE
hotfix/170

### DIFF
--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -113,7 +113,7 @@
                                 Grid.Row="0"
                                 Grid.Column="1"
                                 Margin="0,5,0,0"
-                                Text="{Binding ProductionDateNoTime}"
+                                Text="{Binding ProductionDateShort}"
                                 FontSize="12"
                                 HorizontalOptions="End"
                                 VerticalOptions="Center"/>


### PR DESCRIPTION
# hotfix/170

## Addressed Bug Report
Resolves #170 

## Summary

**Briefly describe the bug being resolved.**

There was a binding issue causing missing Date information on the `CollectionView` `DataTemplate`.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

The `Date` `Label` control was incorrectly bound to the deprecated `PrintTicket.ProductionDateNoTime` property, which has since been renamed to `ProductionDateShort`.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

The Date on which Print Tickets were opened is important to separate previous days' Tickets from the current day's Tickets. Without Date information, Operators may make changes to the incorrect Ticket. 

## Changes

**List the major changes made in this pull request.**

#### `MainPage.xaml`:
- Refactor `OpenPrintTicketsCollectionView` `DataTemplate`:
  - Update the Date `Label`'s bindings to reference the new property name.

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

This change has no potential for unintended impact on existing functionalities.

## Checklist

- [X] Code follows the project's coding standards

- [X] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>