### PR TITLE
bug/175

### DIFF
--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -713,7 +713,7 @@
                                 <Entry
                                     x:Name="DeburrJBKNumberEntry"
                                     Text="{Binding ActiveTicket.Tracked.VariableFields.DeburrJBKNumber.Formatted}"
-                                    TextChanged="OnVariableFieldSetEntryTextChanged"
+                                    Unfocused="OnSerialNumberEntryUnfocused"
                                     MaxLength="3"/>
                             </Border>
                         </HorizontalStackLayout>

--- a/LotCoMPrinter/Views/MainPage.xaml.cs
+++ b/LotCoMPrinter/Views/MainPage.xaml.cs
@@ -581,6 +581,23 @@ public partial class MainPage : ContentPage
 				LotNumberControl.Stroke = Colors.Red;
 			}
 		}
+		// Deburr JBK Number was unfocused
+		if (sender.Equals(DeburrJBKNumberEntry))
+		{
+			if (Sender.Text is null || Sender.Text.Equals(""))
+			{
+				DeburrJBKNumberControl.Stroke = Colors.Red;
+			}
+			try
+			{
+				ViewModel.ActiveTicket!.Tracked.VariableFields.DeburrJBKNumber = new JBKNumber(int.Parse(Sender.Text!));
+				DeburrJBKNumberControl.Stroke = Grey500;
+			}
+			catch
+			{
+				DeburrJBKNumberControl.Stroke = Colors.Red;
+			}
+		}
 	}
 
 	/// <summary>


### PR DESCRIPTION
# bug/175

## Addressed Bug Report
Resolves #175 

## Summary

**Briefly describe the bug being resolved.**

The `DeburrJBKNumberEntry` was automatically formatting values entered by the operator, forcing the JBK to immediately format as 001-009.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

This issue was addressed for the `JBKNumberEntry` in the initial release, but the `DeburrJBKNumberEntry` was missed. The cause of the issue is that the field's `TextChanged` event was immediately creating a new `JBKNumber` object using the first input digit and applying the new `JBKNumber` object's `Formatted` property to the `Text` property of the `Entry` control.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

This is a major issue that barres operators from entering the proper JBK Number in this `Entry` control, corrupting Lot Tracing data.

## Changes

**List the major changes made in this pull request.**

#### `MainPage.xaml.cs`:
- Refactor `OnSerialNumberEntryUnfocused()` event handler:
  - Add a logic block for the `DeburrJBKNumberEntry` control.

#### `MainPage.xaml`:
- Refactor `DeburrJBKNumberEntry` control:
  - Bind the `Unfocused` event to the `OnSerialNumberEntryUnfocused()` handler.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

This implementation should have no unintended impacts to existing functionalities. Its scope is limited to the above mentioned functions of the app.

## Checklist

- [X] Code follows the project's coding standards

- [X] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>