### PR TITLE
bug/179

### DIFF
--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -770,7 +770,8 @@
                                 StrokeShape="RoundRectangle 10,10,10,10">
                                 <Entry
                                     x:Name="ModelNumberEntry"
-                                    Text="{Binding ActiveTicket.Tracked.VariableFields.ModelNumber.Code}"
+                                    Text="{Binding ActiveTicket.Tracked.Part.ModelNumber.Code}"
+                                    IsEnabled="False"
                                     MaxLength="3"/>
                             </Border>
                         </HorizontalStackLayout>


### PR DESCRIPTION
# bug/179

## Addressed Bug Report
Resolves #179 

## Summary

**Briefly describe the bug being resolved.**

Model Number field was not properly locking and auto-filling.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

The binding of the `Text` property on the `ModelNumberEntry` control was improperly bound.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

This issue created more risk for human error with manual input. It was also unnecessary input because the Model Number is already in the runtime data.

## Changes

**List the major changes made in this pull request.**

#### `MainPage.xmal`:
- Refactor `ModelNumberEntry`:
  - Updated bindings to auto-fill the Model from the Part data;
  - Locked control by default.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

No potential for unintended impact on existing functionality.

## Checklist

- [X] Code follows the project's coding standards

- [x] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>