### PR TITLE
bug/179-2

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -271,6 +271,7 @@ public partial class PrintTicket : ObservableObject
     /// <param name="SecondPartialDataSet">A second optional DataSet to include at instantiation.</param>
     public PrintTicket(Process TicketProcess, Part TicketPart, SerializationMode TicketSerializationMode, SerialNumber TicketSerialNumber, DateTime TicketProductionDate, Shift TicketProductionShift, Quantity TicketProductionQuantity, Operator TicketProductionOperator, VariableFieldSet VariableFields, PartialDataSet? FirstPartialDataSet = null, PartialDataSet? SecondPartialDataSet = null)
     {
+        // set the basic info input in the NewPrintTicketForm
         _process = TicketProcess;
         _part = TicketPart;
         _serializationMode = TicketSerializationMode;
@@ -279,7 +280,10 @@ public partial class PrintTicket : ObservableObject
         _productionShift = TicketProductionShift;
         _productionQuantity = TicketProductionQuantity;
         _productionOperator = TicketProductionOperator;
+        // save the passed VariableSet and set its Model Number using the Part selected
         _variableFields = VariableFields;
+        VariableFields.ModelNumber = Part.ModelNumber;
+        // set Partial Datasets if passed
         _firstPartialDataSet = FirstPartialDataSet;
         _secondPartialDataSet = SecondPartialDataSet;
         // calculate binding properties

--- a/LotCoMPrinter/Views/MainPage.xaml
+++ b/LotCoMPrinter/Views/MainPage.xaml
@@ -770,7 +770,7 @@
                                 StrokeShape="RoundRectangle 10,10,10,10">
                                 <Entry
                                     x:Name="ModelNumberEntry"
-                                    Text="{Binding ActiveTicket.Tracked.Part.ModelNumber.Code}"
+                                    Text="{Binding ActiveTicket.Tracked.VariableFields.ModelNumber.Code}"
                                     IsEnabled="False"
                                     MaxLength="3"/>
                             </Border>


### PR DESCRIPTION
# bug/179-2

## Addressed Bug Report
Resolves #179 

## Summary

**Briefly describe the bug being resolved.**

The first implemented fix for the tracked issue created a `NullReferenceException` outside of the intended scope, creating a crash on the Production computers.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

Removing the binding to `PrintTicket.VariableFields.ModelNumber` left the property `null`. When `PrintTicket.SelfValidate()` was invoked, it raised an unhandled `NullReferenceException` and crashed the application.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

This is a major fault in the application that makes it impossible to print Labels at any Process due to the nullification of `ModelNumber`.

## Changes

**List the major changes made in this pull request.**

#### `PrintTicket.cs`:
- Refactor `.ctor()`:
  - Copy the Model Number from the selected Part to the Variable Fields in the `PrintTicket` object.

#### `MainPage.xaml`:
- Refactor `ModelNumberEntry`:
  - Restore proper bindings that update necessary properties before validation steps.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

This implementation should have no unintended impacts on existing functionalities.

## Checklist

- [X] Code follows the project's coding standards

- [X] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**

Signed-off-by: Mason Ritchason <masonritchason@gmail.com>