### PR TITLE
feature/187

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -295,7 +295,7 @@ public partial class PrintTicket : ObservableObject
         HasSecondPartialDataSet = SecondPartialDataSet is not null;
         HasSpace = !(HasFirstPartialDataSet && HasSecondPartialDataSet);
         Title = $"{Part.ModelNumber.Code} {Part.PartName} - {SerialNumber.GetFormattedValue()}";
-        IsPassThrough = _process.Type == OriginationType.PassThrough;
+        IsPassThrough = _process.Origination == OriginationType.PassThrough;
         ProductionDateShort = $"{ProductionDate.Month}/{ProductionDate.Day}";
         if (Process.RequiredFields.JBKNumber && SerializationMode != SerializationMode.JBK)
         {

--- a/LotCoMPrinter/Views/NewPrintTicketForm.xaml
+++ b/LotCoMPrinter/Views/NewPrintTicketForm.xaml
@@ -185,7 +185,7 @@
                         HorizontalOptions="Center"
                         VerticalOptions="Center"
                         x:Name="ProcessTypeLabel"
-                        Text="{Binding Process.Type}"
+                        Text="{Binding Process.Origination}"
                         TextColor="{StaticResource TextDark}"
                         FontSize="14"/>
                 </Border>

--- a/LotCoMPrinter/Views/NewPrintTicketForm.xaml.cs
+++ b/LotCoMPrinter/Views/NewPrintTicketForm.xaml.cs
@@ -110,7 +110,7 @@ public partial class NewPrintTicketForm : Popup
     {
         ViewModel.SelectedProcessIndex = ProcessPicker.SelectedIndex;
         ViewModel.Process = (Process)ProcessPicker.ItemsSource[ViewModel.SelectedProcessIndex]!;
-        ViewModel.SelectedProcessParts = ViewModel.Process.Parts;
+        ViewModel.SelectedProcessParts = ViewModel.Process.PrintParts;
     }
 
     /// <summary>


### PR DESCRIPTION
# feature/187

## Addressed Feature Request
Resolves #187  

## Summary

**Briefly describe the feature being introduced.**

References to modified `Process` properties have been updated to restore intended functionality.

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

The modifications and additions made to the Database Schema (documented in [LotCom Libraries #6](https://github.com/LotCoM/LotCom-libraries/pull/7)) created faulting references throughout the **LotCom** environment. These references impacted the functionality and usability of the application.

## Changes

**List the major changes made in this pull request.**

#### `Process.cs` references:
- Refactored references to `Process.Type`:
  - Changed to reference `Process.Origination`.
- Refactored references to `Process.Parts`:
  - Changed to reference `Process.PrintParts`

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

Because this PR simply refactors references to properties that contain the same information as before, there should be no impact to existing functionalities.

## Checklist

- [X] Code follows the project's coding standards

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**