### PR TITLE
Merge 'feature/199' and 'feature/197' branches

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/PrintJob.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintJob.cs
@@ -9,7 +9,7 @@ public class PrintJob
     /// <summary>
     /// The PartialDataSet Number of Source to use for PartialTag Label PrintJobs.
     /// </summary>
-    private int PartialSetNumber;
+    private int? PartialSetNumber;
 
     /// <summary>
     /// Contains the type 
@@ -43,7 +43,7 @@ public class PrintJob
             }
             else if (Type == PrintJobType.Partial)
             {
-                Label = await PartialTagGenerator.GenerateTagAsync(Source, PartialSetNumber);
+                Label = await PartialTagGenerator.GenerateTagAsync(Source, (int)PartialSetNumber!);
             }
         }
         catch (LabelBuildException _ex)
@@ -52,57 +52,22 @@ public class PrintJob
         }
     }
 
-    /// <summary>
-    /// Creates a Print Job that can generate a BasketLabel and spool a print job to the printing system.
-    /// </summary>
-    /// <param name="Ticket">A PrintTicket object to use as the source of data for this Job.</param>
-    public PrintJob(PrintTicket Ticket)
-    {
-        Type = PrintJobType.Full;
-        Source = Ticket;
-    }
 
-    /// <summary>
-    /// Creates a Print Job that can generate a PartialTag Label and spool a print job to the printing system.
-    /// </summary>
-    /// <param name="Ticket">A PrintTicket object to use as the source of data for this Job.</param>
-    /// <param name="PartialSetNumber">The PartialDataSet Number to use for a PartialTag PrintJob (1 or 2).</param>
-    public PrintJob(PrintTicket Ticket, int PartialSetNumber)
+    public PrintJob(PrintTicket Ticket, PrintJobType Type, int? PartialSetNumber = null)
     {
-        Type = PrintJobType.Partial;
         Source = Ticket;
+        this.Type = Type;
         this.PartialSetNumber = PartialSetNumber;
+
+        if (Type == PrintJobType.Partial)
+        {
+            if (PartialSetNumber != 1 && PartialSetNumber != 2)
+            {
+                throw new ArgumentException("Partial print jobs must have a partial set number");
+            }
+        }
     }
 
-    /// <summary>
-    /// Creates a Print Job that can generate a Reprint Label from a PrintTicket.
-    /// </summary>
-    /// <param name="Ticket"></param>
-    /// <param name="Type">PrintJobType.Full or PrintJobType.Reprint.</param>
-    public static PrintJob CreateReprintJob(PrintTicket Ticket)
-    {
-        /**
-        Jared: this method is flawed. 
-
-        Right now, it runs just like the basic constructor.
-        The default is to create a `PrintJob` to print a `Full` Label.
-        This will treat the Label as a 'new' one, which will prompt logging.
-        
-        Two questions:
-        - Is this what we want?
-        - If not, how can we make a `PrintJob` that won't log?
-
-        That's your job!
-
-        Look at the `PrintLogger` class to see how it Logs.
-        Understanding that class will help you a lot.
-
-        Good luck!
-        **/
-        PrintJob ReprintJob = new PrintJob(Ticket);
-        ReprintJob.Type = PrintJobType.Full; // Modify this so it doesn't Log
-        return ReprintJob;
-    }
 
     /// <summary>
     /// Runs the Print Job (creates a Handler for the Job and spools it to the OS' printing system).

--- a/LotCoMPrinter/Models/Datatypes/PrintJob.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintJob.cs
@@ -37,13 +37,13 @@ public class PrintJob
         // generate a new Label image and store it in the Label property
         try
         {
-            if (Type == PrintJobType.Full)
-            {
-                Label = await LabelGenerator.GenerateLabelAsync(Source);
-            }
-            else if (Type == PrintJobType.Partial)
+            if (Type == PrintJobType.Partial)
             {
                 Label = await PartialTagGenerator.GenerateTagAsync(Source, (int)PartialSetNumber!);
+            }
+            else
+            {
+                Label = await LabelGenerator.GenerateLabelAsync(Source);
             }
         }
         catch (LabelBuildException _ex)

--- a/LotCoMPrinter/Models/Enums/PrintJobType.cs
+++ b/LotCoMPrinter/Models/Enums/PrintJobType.cs
@@ -3,5 +3,6 @@ namespace LotCoMPrinter.Models.Enums;
 public enum PrintJobType
 {
     Full,
-    Partial
+    Partial,
+    Reprint
 }

--- a/LotCoMPrinter/ViewModels/MainPageViewModel.cs
+++ b/LotCoMPrinter/ViewModels/MainPageViewModel.cs
@@ -310,7 +310,7 @@ public partial class MainPageViewModel : ObservableObject
         {
             throw new ArgumentException(_ex.Message);
         }
-        PrintJob Job = new PrintJob(EditorTicket.Tracked);
+        PrintJob Job = new PrintJob(EditorTicket.Tracked, PrintJobType.Full);
         bool Printed;
         // attempt to run the Print Job
         try
@@ -432,7 +432,7 @@ public partial class MainPageViewModel : ObservableObject
             throw new ArgumentException(_argEx.Message);
         }
         // create a new PrintJob from the PartialDataSet and attempt to run it
-        PrintJob Job = new PrintJob(EditorTicket.Tracked, PartialSetNumber);
+        PrintJob Job = new PrintJob(EditorTicket.Tracked, PrintJobType.Partial, PartialSetNumber);
         bool Printed;
         try
         {

--- a/LotCoMPrinter/ViewModels/MainPageViewModel.cs
+++ b/LotCoMPrinter/ViewModels/MainPageViewModel.cs
@@ -7,6 +7,7 @@ using LotCom.Enums;
 using LotCoMPrinter.Models.Datasources;
 using LotCoMPrinter.Models.Datatypes;
 using LotCoMPrinter.Models.Exceptions;
+using LotCoMPrinter.Models.Enums;
 
 namespace LotCoMPrinter.ViewModels;
 
@@ -455,6 +456,7 @@ public partial class MainPageViewModel : ObservableObject
     /// <returns></returns>
     public async Task<bool> ReprintLabel(PrintTicket ReprintTicket)
     {
+
         /**
         Jared: implement your solution here.
         
@@ -463,20 +465,37 @@ public partial class MainPageViewModel : ObservableObject
               - It does a very similar thing but needs to be tweaked for this method.
 
         You should:
-        1. Create a new `PrintJob` from `ReprintTicket`;
+        x 1. Create a new `PrintJob` from `ReprintTicket`;
         2. Make sure that `PrintJob` object is set to Reprint:
            - This is not a new Label, so we need to skip logging;
-        3. Run the `PrintJob`;
-        4. Handle any printing exceptions that might occur:
+        x 3. Run the `PrintJob`;
+        x 4. Handle any printing exceptions that might occur:
            - Hint: look at `PrintJob.Run()`
            - You will be able to see which exceptions it throws;
-        5. Capture the results of that run:
+        x 5. Capture the results of that run:
            - Hint: the ReprintLabel() method will tell you what 
              type of variable you need to capture and return;
-        6. Return that result.
+        x 6. Return that result.
         
         Good Luck! As always, questions are welcome!!
         **/
+
+        PrintJob Job = new PrintJob(ReprintTicket, PrintJobType.Reprint);
+        bool Printed;
+        // attempt to run the Print Job
+        try
+        {
+            Printed = await Job.Run();
+        }
+        catch (LabelBuildException)
+        {
+            throw new PrintRequestException("Could not create a Label from the entered information.");
+        }
+        catch (PrintRequestException)
+        {
+            throw new PrintRequestException("Failed to execute the print job for the generated Label.");
+        }
+        return Printed;
     }
 }
 # pragma warning restore CA1416 // Validate platform compatibility


### PR DESCRIPTION
These feature branches have overlapping history and need to be merged together.

Branch `feature/199` was based from `feature/197` with changes to `develop`. To follow proper branching conventions, `feature/199` should merge back to its base, `feature/197`, instead of `develop`.