### PR TITLE
feature/221

### DIFF
--- a/LotCoMPrinter/Models/Services/LabelGenerator.cs
+++ b/LotCoMPrinter/Models/Services/LabelGenerator.cs
@@ -43,7 +43,7 @@ public static class LabelGenerator
             }
             if (RequiredFields.DieNumber)
             {
-                Data.Add(Ticket.VariableFields.DieNumber!.Literal.ToString());
+                Data.Add(Ticket.VariableFields.DieNumber!.Formatted);
             }
             if (RequiredFields.HeatNumber)
             {
@@ -93,7 +93,7 @@ public static class LabelGenerator
             }
             if (RequiredFields.DieNumber)
             {
-                Body.Add($"Die #: {Ticket.VariableFields.DieNumber!.Literal}");
+                Body.Add($"Die #: {Ticket.VariableFields.DieNumber!.Formatted}");
             }
             if (RequiredFields.HeatNumber)
             {

--- a/LotCoMPrinter/Models/Services/PrintLogger.cs
+++ b/LotCoMPrinter/Models/Services/PrintLogger.cs
@@ -37,7 +37,7 @@ public static class PrintLogger
         }
         if (Requirements.DieNumber)
         {
-            Log = $"{Log},{JobSource.VariableFields.DieNumber!.Literal}";
+            Log = $"{Log},{JobSource.VariableFields.DieNumber!.Formatted}";
         }
         if (Requirements.HeatNumber)
         {

--- a/LotCoMPrinter/Views/TicketEditorPage.xaml
+++ b/LotCoMPrinter/Views/TicketEditorPage.xaml
@@ -864,9 +864,9 @@
                             StrokeShape="RoundRectangle 0">
                             <Entry
                                 x:Name="DieNumberEntry"
-                                Text="{Binding EditorTicket.Tracked.VariableFields.DieNumber.Literal}"
+                                Text="{Binding EditorTicket.Tracked.VariableFields.DieNumber.Formatted}"
                                 TextChanged="OnVariableFieldSetEntryTextChanged"
-                                MaxLength="2"
+                                MaxLength="3"
                                 FontSize="20"
                                 WidthRequest="100"/>
                         </Border>

--- a/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
+++ b/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
@@ -406,7 +406,7 @@ public partial class TicketEditorPage : ContentPage
 		{
 			try
 			{
-				ViewModel.EditorTicket.Tracked.VariableFields.DieNumber = new DieNumber(int.Parse(e.NewTextValue));
+				ViewModel.EditorTicket.Tracked.VariableFields.DieNumber = new DieNumber(e.NewTextValue);
 				DieNumberControl.Stroke = Grey500;
 			}
 			catch


### PR DESCRIPTION
# feature/221

## Addressed Feature Request
Resolves #221

## Summary

**Briefly describe the feature being introduced.**

The Die Number entry now accepts an optional 'A' or 'B' at the end of its value to accommodate split Dies.

## Rationale

**Explain the reasoning behind this feature and its benefits to the project.**

Due to the way a split Die functions, they require an A and B distinction. This distinction was previously impossible to make, which impacted the accuracy of the Lot tracing data.

## Changes

**List the major changes made in this pull request.**

#### `LabelGenerator.cs`:
- Refactor `GenerateBody()` and `GenerateCode()` methods:
  - Reference `Formatted` property of `DieNumber` to include proper values.

#### `PrintLogger.cs`:
- Refactor `GenerateLog()` method:
  - Reference `Formatted` property of `DieNumber` to log proper value.

#### `TicketEditorPage.xaml.cs` & `TicketEditorPage.xaml`:
- Refactor `DieNumberEntry` component:
  - Update bindings and validations to allow A/B in Die Number entry.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

While this PR does not implement an new functionality, it touches the Die Number entry process. This component should be monitored for unexpected behavior.

## Checklist

- [X] Code follows the project's coding standards

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**
