### PR TITLE
bug/219

### DIFF
--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -623,67 +623,6 @@ public partial class PrintTicket : ObservableObject
         return NewTicket;
     }
 
-    public override int GetHashCode()
-    {
-        throw new NotImplementedException();
-    }
-
-    /// <summary>
-    /// Evaluates equivalency of two PrintTicket objects based on data contained in the objects.
-    /// </summary>
-    /// <param name="Object"></param>
-    /// <returns></returns>
-    public override bool Equals(object? Object)
-    {
-        if (Object is null)
-        {
-            return false;
-        }
-        if (!Object.GetType().Equals(typeof(PrintTicket)))
-        {
-            return false;
-        }
-        PrintTicket Compare = (PrintTicket)Object;
-        if
-        (
-            !Compare.Process.Equals(Process)
-            || !Compare.Part.Equals(Part)
-            || Compare.SerializationMode != SerializationMode
-            || !Compare.SerialNumber.Equals(SerialNumber)
-            || !Compare.ProductionDate.Ticks.Equals(ProductionDate.Ticks)
-            || !Compare.ProductionShift.Equals(ProductionShift)
-            || Compare.ProductionQuantity.Equals(ProductionQuantity)
-            || !Compare.ProductionOperator.Equals(ProductionOperator)
-            || !Compare.VariableFields.Equals(VariableFields)
-        )
-        {
-            return false;
-        }
-        if (FirstPartialDataSet is not null)
-        {
-            if
-            (
-                Compare.FirstPartialDataSet is null
-                || !Compare.FirstPartialDataSet.Equals(FirstPartialDataSet)
-            )
-            {
-                return false;
-            }
-        }
-        if (SecondPartialDataSet is not null)
-        {
-            if
-            (
-                Compare.SecondPartialDataSet is null
-                || !Compare.SecondPartialDataSet.Equals(SecondPartialDataSet)
-            )
-            {
-                return false;
-            }
-        }
-        return true;
-    }
-
     /// <summary>
     /// Creates a deep copy of the Source, removing all referential equivalencies.
     /// </summary>

--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -623,6 +623,67 @@ public partial class PrintTicket : ObservableObject
         return NewTicket;
     }
 
+    public override int GetHashCode()
+    {
+        throw new NotImplementedException();
+    }
+
+    /// <summary>
+    /// Evaluates equivalency of two PrintTicket objects based on data contained in the objects.
+    /// </summary>
+    /// <param name="Object"></param>
+    /// <returns></returns>
+    public override bool Equals(object? Object)
+    {
+        if (Object is null)
+        {
+            return false;
+        }
+        if (!Object.GetType().Equals(typeof(PrintTicket)))
+        {
+            return false;
+        }
+        PrintTicket Compare = (PrintTicket)Object;
+        if
+        (
+            !Compare.Process.Equals(Process)
+            || !Compare.Part.Equals(Part)
+            || Compare.SerializationMode != SerializationMode
+            || !Compare.SerialNumber.Equals(SerialNumber)
+            || !Compare.ProductionDate.Ticks.Equals(ProductionDate.Ticks)
+            || !Compare.ProductionShift.Equals(ProductionShift)
+            || Compare.ProductionQuantity.Equals(ProductionQuantity)
+            || !Compare.ProductionOperator.Equals(ProductionOperator)
+            || !Compare.VariableFields.Equals(VariableFields)
+        )
+        {
+            return false;
+        }
+        if (FirstPartialDataSet is not null)
+        {
+            if
+            (
+                Compare.FirstPartialDataSet is null
+                || !Compare.FirstPartialDataSet.Equals(FirstPartialDataSet)
+            )
+            {
+                return false;
+            }
+        }
+        if (SecondPartialDataSet is not null)
+        {
+            if
+            (
+                Compare.SecondPartialDataSet is null
+                || !Compare.SecondPartialDataSet.Equals(SecondPartialDataSet)
+            )
+            {
+                return false;
+            }
+        }
+        return true;
+    }
+
     /// <summary>
     /// Creates a deep copy of the Source, removing all referential equivalencies.
     /// </summary>

--- a/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/PrintTicket.cs
@@ -924,4 +924,13 @@ public partial class PrintTicket : ObservableObject
         }
         return FullOperator;
     }
+
+    /// <summary>
+    /// Updates the Serial Number string attached to the end of a PrintTicket's title.
+    /// </summary>
+    /// <param name="NewNumber"></param>
+    public void UpdateTitleSerialNumber(string NewNumber)
+    {
+        Title = $"{Part.ModelNumber.Code} {Part.PartName} - {NewNumber}";
+    }
 }

--- a/LotCoMPrinter/Models/Datatypes/TrackedPrintTicket.cs
+++ b/LotCoMPrinter/Models/Datatypes/TrackedPrintTicket.cs
@@ -1,12 +1,11 @@
 using CommunityToolkit.Mvvm.ComponentModel;
-using LotCom.Types;
 
 namespace LotComPrinter.Models.Datatypes;
 
 public partial class TrackedPrintTicket : ObservableObject
 {
     /// <summary>
-    /// A Copy of the PrintTicket that the object was made to track.
+    /// The PrintTicket that the object was made to track.
     /// Does not receive any edits.
     /// </summary>
     [ObservableProperty]
@@ -24,7 +23,7 @@ public partial class TrackedPrintTicket : ObservableObject
     /// <param name="Ticket"></param>
     public TrackedPrintTicket(PrintTicket Ticket)
     {
-        Untracked = PrintTicket.DeepCopy(Ticket);
+        Untracked = Ticket;
         Tracked = PrintTicket.DeepCopy(Ticket);
     }
 
@@ -33,7 +32,7 @@ public partial class TrackedPrintTicket : ObservableObject
     /// </summary>
     public void DiscardChanges()
     {
-        Tracked = Untracked;
+        Tracked = PrintTicket.DeepCopy(Untracked);
     }
 
     /// <summary>
@@ -42,6 +41,6 @@ public partial class TrackedPrintTicket : ObservableObject
     /// <returns></returns>
     public void MergeChanges()
     {
-        Untracked = Tracked;
+        Untracked = PrintTicket.DeepCopy(Tracked);
     }
 }

--- a/LotCoMPrinter/Models/Services/Serializer.cs
+++ b/LotCoMPrinter/Models/Services/Serializer.cs
@@ -12,8 +12,13 @@ public static class Serializer
     /// <param name="Process"></param>
     /// <param name="Part"></param>
     /// <returns></returns>
-    public static async Task<SerialNumber> Serialize(Process Process, Part Part)
+    public static async Task<SerialNumber?> Serialize(Process Process, Part Part)
     {
+        // check if the process is serialized
+        if (Process.Serialization == SerializationMode.None)
+        {
+            return null;
+        }
         // retrieve a new SerialNumber for the Part
         SerialNumber Number;
         if (Process.Serialization == SerializationMode.JBK)

--- a/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
+++ b/LotCoMPrinter/ViewModels/NewPrintTicketFormViewModel.cs
@@ -224,9 +224,18 @@ public partial class NewPrintTicketFormViewModel : ObservableObject
         SerialNumber? TicketNumber = await Serializer.Serialize(Process, Part);
         if (TicketNumber is null)
         {
-            throw new SerializationException("Failed to retrieve a Serial Number for the new Print Ticket.");
+            // a serial number is needed
+            if (Process.Serialization != SerializationMode.None)
+            {
+                throw new SerializationException("Failed to retrieve a Serial Number for the new Print Ticket.");
+            }
+            // pass-through process
+            else
+            {
+                TicketNumber = new SerialNumber(SerializationMode.None, Part, 0);
+            }
         }
-        PrintTicket NewTicket = new PrintTicket(Process, Part, Process.Serialization, TicketNumber, DateTime.Now, (Shift)ProductionShift, ProductionQuantity, ProductionOperator, new VariableFieldSet());
+        PrintTicket NewTicket = new PrintTicket(Process, Part, Process.Serialization, TicketNumber, DateTime.Now, ProductionShift, ProductionQuantity, ProductionOperator, new VariableFieldSet());
         // apply the SerialNumber to the appropriate field and return the new Ticket
         if (NewTicket.SerializationMode == SerializationMode.JBK)
         {

--- a/LotCoMPrinter/ViewModels/TicketEditorPageViewModel.cs
+++ b/LotCoMPrinter/ViewModels/TicketEditorPageViewModel.cs
@@ -92,6 +92,31 @@ public class TicketEditorPageViewModel : ObservableObject
     }
 
     /// <summary>
+    /// Goes through the NavigationStack to add the Editor's Untracked ticket to the Open Ticket List.
+    /// </summary>
+    /// <param name="Previous"></param>
+    /// <returns></returns>
+    /// <exception cref="SystemException"></exception>
+    public async Task AddTicket(Page Previous)
+    {
+        // confirm that the passed Page is a MainPage
+        if (!Previous.GetType().Equals(typeof(MainPage)))
+        {
+            throw new SystemException("Cannot navigate to previous MainPage view to add this Print Ticket.");
+        }
+        // convert the Page to MainPage, add the Ticket, and save the open ticket list
+        MainPage Main = (MainPage)Previous;
+        try
+        {
+            await Main.ViewModel.AddNewOpenPrintTicket(EditorTicket!.Untracked);
+        }
+        catch (SystemException)
+        {
+            throw;
+        }
+    }
+
+    /// <summary>
     /// Attempts to create and run a Label Print Job from EditorTicket.Tracked.
     /// Removes EditorTicket from OpenPrintTickets.
     /// </summary>

--- a/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
+++ b/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
@@ -1,4 +1,5 @@
 using CommunityToolkit.Maui.Views;
+using LotCom.Enums;
 using LotCom.Types;
 using LotComPrinter.Models.Datatypes;
 using LotComPrinter.Models.Exceptions;
@@ -198,7 +199,7 @@ public partial class TicketEditorPage : ContentPage
 				);
 				return;
 			}
-			// save changes to the Ticket and add updated Ticket to OpenTicketsList
+			// save changes to the Ticket
 			if (!Removed)
 			{
 				this.ShowPopup
@@ -214,6 +215,22 @@ public partial class TicketEditorPage : ContentPage
 				return;
 			}
 			ViewModel.EditorTicket!.MergeChanges();
+			// ensure that Pass-through tickets have a Serial Number in their title
+			if (ViewModel.EditorTicket.Untracked.Process.PassThroughType == PassThroughType.JBK)
+			{
+				if (ViewModel.EditorTicket.Untracked.VariableFields.JBKNumber is not null)
+				{
+					ViewModel.EditorTicket.Untracked.UpdateTitleSerialNumber(ViewModel.EditorTicket.Untracked.VariableFields.JBKNumber!.Formatted);
+				}
+			}
+			else if (ViewModel.EditorTicket.Untracked.Process.PassThroughType == PassThroughType.Lot)
+			{
+				if (ViewModel.EditorTicket.Untracked.VariableFields.LotNumber is not null)
+				{
+					ViewModel.EditorTicket.Untracked.UpdateTitleSerialNumber(ViewModel.EditorTicket.Untracked.VariableFields.LotNumber!.Formatted);
+				}
+			}
+			// add the modified ticket to the Open Tickets list
 			try
 			{
 				await ViewModel.AddTicket(Navigation.NavigationStack[^2]);

--- a/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
+++ b/LotCoMPrinter/Views/TicketEditorPage.xaml.cs
@@ -178,11 +178,45 @@ public partial class TicketEditorPage : ContentPage
 		// close was confirmed
 		else
 		{
-			// save and close the Ticket Editor Menu window
+			// remove the old version of the Ticket
+			bool Removed;
+			try
+			{
+				Removed = await ViewModel.DeleteTicket(Navigation.NavigationStack[^2]);
+			}
+			catch (SystemException)
+			{
+				this.ShowPopup
+				(
+					new BasicPopup
+					(
+						"Unexpected Error",
+						"We encountered an unexpected error. Please see Management to resolve this issue." +
+						"\n\nReference message: " +
+						"Could not remove Editor Ticket from the cache."
+					)
+				);
+				return;
+			}
+			// save changes to the Ticket and add updated Ticket to OpenTicketsList
+			if (!Removed)
+			{
+				this.ShowPopup
+				(
+					new BasicPopup
+					(
+						"Unexpected Error",
+						"We encountered an unexpected error. Please see Management to resolve this issue." +
+						"\n\nReference message: " +
+						"Could not remove Editor Ticket from the cache."
+					)
+				);
+				return;
+			}
 			ViewModel.EditorTicket!.MergeChanges();
 			try
 			{
-				await ViewModel.SaveTickets(Navigation.NavigationStack[^2]);
+				await ViewModel.AddTicket(Navigation.NavigationStack[^2]);
 			}
 			catch (SystemException)
 			{


### PR DESCRIPTION
# bug/219

## Addressed Bug Report
Resolves #219 

## Summary

**Briefly describe the bug being resolved.**

Print Tickets created for Pass-through Processes were previously being Serialized by Lot Numbers.

## Root Cause(s)/Faults

**Give a detailed explanation of the root causes addressed by this pull request.**

A case where the `SerializationMode.None` `enum` value was ignored caused `Serializer` to always give non-JBK Tickets a Lot Number.

## Rationale

**Explain the reasoning behind the solution introduced by this pull request and any additional benefits to the project.**

Pass-through Processes should not receive Serial Numbers. They refer to the Previous Process' Serial Number. Consuming extra Lot Numbers causes issues with the FIFO structure.

## Changes

**List the major changes made in this pull request.**

#### `PrintTicket.cs`:
- Add `UpdateTitleSerialNumber()`:
  - Allows dynamic re-titling of Pass-through Labels.

#### `TrrackedPrintTicket.cs`:
- Refactor:
  - Utilize `PrintTicket.DeepCopy()` method instead of shallow copying.

#### `Serializer.cs`:
- Refactor `Serialize()`:
  - Add logic to ignore `SerializationMode.None`.

#### `TicketEditorPageViewModel.cs`:
- Add `AddTicket()`:
  - Adds a `PrintTicket` to the `OpenPrintTickets` List.

## New classes

**List any new classes or members implemented in this pull request.**

## Removed classes

**List any classes or members that have been removed or deprecated by this pull request.**

## Impact

**Discuss any potential impacts this feature may have on existing functionalities.**

## Checklist

- [X] Code follows the project's coding standards

- [X] The solution thoroughly and effectively addresses the root cause mentioned above

- [X] The documentation has been updated to reflect the new feature

## Additional Notes

**Any additional information or context relevant to this PR.**