### PR TITLE
hotfix/1.0.0.21

### DIFF
--- a/LotCoMPrinter/Views/NewPrintTicketForm.xaml.cs
+++ b/LotCoMPrinter/Views/NewPrintTicketForm.xaml.cs
@@ -76,7 +76,6 @@ public partial class NewPrintTicketForm : Popup
     /// <param name="e"></param>
     private async void OnProcessPickerFocused(object sender, EventArgs e)
     {
-        ProcessPicker.IsEnabled = false;
         try
         {
             await ViewModel.LoadProcesses();
@@ -87,7 +86,6 @@ public partial class NewPrintTicketForm : Popup
             CancellationTokenSource TokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             await CloseAsync(Output, TokenSource.Token);
         }
-        ProcessPicker.IsEnabled = true;
     }
 
     /// <summary>
@@ -97,7 +95,6 @@ public partial class NewPrintTicketForm : Popup
     /// <param name="e"></param>
     private async void OnPartPickerFocused(object sender, EventArgs e)
     {
-        PartPicker.IsEnabled = false;
         try
         {
             await ViewModel.LoadParts();
@@ -108,7 +105,6 @@ public partial class NewPrintTicketForm : Popup
             CancellationTokenSource TokenSource = new CancellationTokenSource(TimeSpan.FromSeconds(5));
             await CloseAsync(Output, TokenSource.Token);
         }
-        PartPicker.IsEnabled = true;
     }
 
     /// <summary>


### PR DESCRIPTION
### hotfix/1.0.0.21

Hotfix patch that resolves an issue where the app immediately closes Picker dropdowns. This occurs due to a misconfiguration of Enabled properties.